### PR TITLE
Fix progress slider visually resets to zero on page transition when paused.

### DIFF
--- a/lib/src/features/player/application/audio_handler_service.dart
+++ b/lib/src/features/player/application/audio_handler_service.dart
@@ -372,6 +372,12 @@ class AudioHandlerService extends BaseAudioHandler {
     });
   }
 
+  PositionData get lastPositionData => PositionData(
+        _player.position,
+        _player.bufferedPosition,
+        _player.duration ?? Duration.zero,
+      );
+
   Stream<PositionData> get positionData {
     return Rx.combineLatest3(
       // AudioService.position has a weird behavior, maybe a bug, wherein

--- a/lib/src/features/player/presentation/progress_slider.dart
+++ b/lib/src/features/player/presentation/progress_slider.dart
@@ -8,18 +8,10 @@ class ProgressSlider extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final positionValue = ref.watch(progressSliderControllerProvider);
+    final positionData = ref.watch(progressSliderControllerProvider);
     return ProgressBar(
-      progress: positionValue.when(
-        loading: () => Duration.zero,
-        error: (_, __) => Duration.zero,
-        data: (positionData) => positionData.position,
-      ),
-      total: positionValue.when(
-        loading: () => Duration.zero,
-        error: (_, __) => Duration.zero,
-        data: (positionData) => positionData.duration,
-      ),
+      progress: positionData.position,
+      total: positionData.duration,
       // Calling this onSeekProvider is a workaround for an issue described in
       // detail in progress_slider_controller.dart.
       onSeek: (position) => ref.read(onSeekProvider(position)),

--- a/lib/src/features/player/presentation/progress_slider_controller.dart
+++ b/lib/src/features/player/presentation/progress_slider_controller.dart
@@ -8,8 +8,16 @@ part 'progress_slider_controller.g.dart';
 @riverpod
 class ProgressSliderController extends _$ProgressSliderController {
   @override
-  AsyncValue<PositionData> build() {
-    return ref.watch(positionDataStreamProvider);
+  PositionData build() {
+    // If the stream isn't active when the widget loads, get the most recent
+    // position data from the audio handler service.
+    return ref.watch(positionDataStreamProvider).when(
+          loading: () =>
+              ref.read(audioHandlerProvider).requireValue.lastPositionData,
+          error: (_, __) =>
+              ref.read(audioHandlerProvider).requireValue.lastPositionData,
+          data: (positionData) => positionData,
+        );
   }
 
   // Using this method throws the following exception:

--- a/lib/src/features/player/presentation/progress_slider_controller.g.dart
+++ b/lib/src/features/player/presentation/progress_slider_controller.g.dart
@@ -157,12 +157,12 @@ class _OnSeekProviderElement extends AutoDisposeProviderElement<Object?>
 }
 
 String _$progressSliderControllerHash() =>
-    r'2b4bb4418c39cce6593f7956afbe3602ff4265d8';
+    r'1e4d5cbd7e05adf7ce25cbc49d1a6e285df2a8db';
 
 /// See also [ProgressSliderController].
 @ProviderFor(ProgressSliderController)
 final progressSliderControllerProvider = AutoDisposeNotifierProvider<
-    ProgressSliderController, AsyncValue<PositionData>>.internal(
+    ProgressSliderController, PositionData>.internal(
   ProgressSliderController.new,
   name: r'progressSliderControllerProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -172,7 +172,6 @@ final progressSliderControllerProvider = AutoDisposeNotifierProvider<
   allTransitiveDependencies: null,
 );
 
-typedef _$ProgressSliderController
-    = AutoDisposeNotifier<AsyncValue<PositionData>>;
+typedef _$ProgressSliderController = AutoDisposeNotifier<PositionData>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package


### PR DESCRIPTION
The progress slider on the player page would visually reset to zero when navigating to the page when the player was paused whether or not the play page had been loaded in the current session of not.

I fixed it by having the controller return the latest position saved by the audio handler service if the position stream provider is in a loading state. This required adding a new getter to the audio handler service to retrieve the last position data.