### PR TITLE
Improve routing around player screen.

### DIFF
--- a/lib/src/features/player/presentation/buttons.dart
+++ b/lib/src/features/player/presentation/buttons.dart
@@ -157,7 +157,7 @@ class OpenTranscriptButton extends StatelessWidget {
         child: Ink(
           child: InkWell(
             borderRadius: BorderRadius.circular(32),
-            onTap: () => context.goNamed(AppRoute.transcript),
+            onTap: () => context.pushNamed(AppRoute.transcript),
             child: Center(
               child: Padding(
                 padding: const EdgeInsets.all(8),

--- a/lib/src/features/player/presentation/player_screen.dart
+++ b/lib/src/features/player/presentation/player_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:go_router/go_router.dart';
 import 'package:kantan/config.dart';
 import 'package:kantan/src/common_widgets/async_value_widget.dart';
 import 'package:kantan/src/features/player/application/audio_handler_service.dart';

--- a/lib/src/features/transcript/presentation/transcript_player_controls.dart
+++ b/lib/src/features/transcript/presentation/transcript_player_controls.dart
@@ -264,7 +264,7 @@ class CloseTranscriptButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return IconButton(
       icon: const Icon(Icons.close_rounded),
-      onPressed: context.pop,
+      onPressed: () => context.goNamed(AppRoute.player),
     );
   }
 }

--- a/lib/src/routing/app_router.dart
+++ b/lib/src/routing/app_router.dart
@@ -24,13 +24,11 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             path: AppRoute.player,
             name: AppRoute.player,
             builder: (_, __) => const PlayerScreen(),
-            routes: [
-              GoRoute(
-                path: AppRoute.transcript,
-                name: AppRoute.transcript,
-                builder: (_, __) => const TranscriptScreen(),
-              ),
-            ],
+          ),
+          GoRoute(
+            path: AppRoute.transcript,
+            name: AppRoute.transcript,
+            builder: (_, __) => const TranscriptScreen(),
           ),
         ],
       ),

--- a/lib/src/routing/app_router.dart
+++ b/lib/src/routing/app_router.dart
@@ -12,6 +12,7 @@ class AppRoute {
 
 final goRouterProvider = Provider<GoRouter>((ref) {
   return GoRouter(
+    debugLogDiagnostics: true,
     initialLocation: '/',
     routes: [
       GoRoute(

--- a/lib/src/routing/app_router.dart
+++ b/lib/src/routing/app_router.dart
@@ -24,11 +24,13 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             path: AppRoute.player,
             name: AppRoute.player,
             builder: (_, __) => const PlayerScreen(),
-          ),
-          GoRoute(
-            path: AppRoute.transcript,
-            name: AppRoute.transcript,
-            builder: (_, __) => const TranscriptScreen(),
+            routes: [
+              GoRoute(
+                path: AppRoute.transcript,
+                name: AppRoute.transcript,
+                builder: (_, __) => const TranscriptScreen(),
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/src/routing/app_router.dart
+++ b/lib/src/routing/app_router.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kantan/config.dart';
 import 'package:kantan/src/features/player/presentation/player_screen.dart';
 import 'package:kantan/src/features/transcript/presentation/transcript_screen.dart';
 import 'package:kantan/src/kantan_player_app.dart';
@@ -23,6 +25,10 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           GoRoute(
             path: AppRoute.player,
             name: AppRoute.player,
+            redirect: (context, state) {
+              final width = MediaQuery.sizeOf(context).width;
+              return width > Config.mediumBreakpoint ? '/' : null;
+            },
             builder: (_, __) => const PlayerScreen(),
           ),
           GoRoute(


### PR DESCRIPTION
When a user navigates to the transcript screen from either the player screen or the home screen, now the back action should return them reliable to that page.

There is one (probably extremely rare) situation that might lead to unexpected behavior:

1. The app is using a wide layout.
2. The user opens the transcript screen.
3. The user resizes the app window below the compact layout threshold.
4. The user backs out of the transcript screen.
5. The app will navigate to the tracks list screen.

The user probably expected to be brought back to the player screen, but because the transcript route was pushed from the home layout, popping the transcript screen will go back to the home route, which shows the tracks list screen when using a the most compact layout.