### PR TITLE
Allow or prevent local-dependent layout direction.

### DIFF
--- a/lib/src/features/player/presentation/player_screen.dart
+++ b/lib/src/features/player/presentation/player_screen.dart
@@ -310,7 +310,7 @@ class TrackInfo extends ConsumerWidget {
     final trackTitleTextStyle = style?.trackTitleTextStyle;
     final trackDescriptionTextStyle = style?.trackDescriptionTextStyle;
 
-    String _trackNumberString(Track track) {
+    String trackNumberString(Track track) {
       final trackObject = localizations.trackObject;
       final discObject = localizations.discObject;
       final trackNumber = track.track;
@@ -340,7 +340,7 @@ class TrackInfo extends ConsumerWidget {
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   Text(
-                    _trackNumberString(track),
+                    trackNumberString(track),
                     style: Theme.of(context).textTheme.titleLarge?.merge(
                       trackNumberTextStyle,
                     ),

--- a/lib/src/features/player/presentation/player_screen.dart
+++ b/lib/src/features/player/presentation/player_screen.dart
@@ -89,22 +89,26 @@ class ResponsiveButtonGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        if (constraints.maxHeight > Config.fullButtonGridBreakpoint) {
-          return ButtonGrid(
-            showOpenTranscriptButton: showOpenTranscriptButton,
-          );
-        } else if (constraints.maxHeight >= Config.smallButtonGridBreakpoint) {
-          return SmallButtonGrid(
-            showOpenTranscriptButton: showOpenTranscriptButton,
-          );
-        } else {
-          return VerySmallButtonGrid(
-            showOpenTranscriptButton: showOpenTranscriptButton,
-          );
-        }
-      },
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          if (constraints.maxHeight > Config.fullButtonGridBreakpoint) {
+            return ButtonGrid(
+              showOpenTranscriptButton: showOpenTranscriptButton,
+            );
+          } else if (constraints.maxHeight >=
+              Config.smallButtonGridBreakpoint) {
+            return SmallButtonGrid(
+              showOpenTranscriptButton: showOpenTranscriptButton,
+            );
+          } else {
+            return VerySmallButtonGrid(
+              showOpenTranscriptButton: showOpenTranscriptButton,
+            );
+          }
+        },
+      ),
     );
   }
 }

--- a/lib/src/features/transcript/presentation/transcript_player_controls.dart
+++ b/lib/src/features/transcript/presentation/transcript_player_controls.dart
@@ -40,6 +40,7 @@ class TranscriptPlayerControls extends StatelessWidget {
               children: [
                 if (isFullscreen) TranscriptProgressSlider(),
                 Row(
+                  textDirection: TextDirection.ltr,
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     if (isFullscreen) ...[

--- a/lib/src/kantan_player_app.dart
+++ b/lib/src/kantan_player_app.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_localized_locales/flutter_localized_locales.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/src/kantan_player_app.dart
+++ b/lib/src/kantan_player_app.dart
@@ -68,7 +68,6 @@ class MediumLayout extends StatelessWidget {
         minimum: EdgeInsets.all(Config.layoutOuterPadding),
         child: Row(
           spacing: Config.layoutSpacing,
-          textDirection: TextDirection.ltr,
           children: [
             Expanded(
               flex: 1,
@@ -102,7 +101,6 @@ class LargeLayout extends StatelessWidget {
         ),
         // minimum: EdgeInsets.all(Config.layoutOuterPadding),
         child: Row(
-          textDirection: TextDirection.ltr,
           spacing: Config.layoutSpacing,
           children: [
             Expanded(


### PR DESCRIPTION
This pull request keeps playback controls consistent across locales for both the player screen and the transcript controls. Locale-dependent layout is now allowed for the medium and large layouts.