### PR TITLE
FIX: Floating mini player occludes last track.

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -37,6 +37,7 @@ class Config {
   static double get miniPlayerWidthProportion => 0.75;
   static double get miniPlayerMaxWidth => 250;
   static double get miniPlayerButtonSize => 72;
+  static double get trackListScrollBottomPadding => 120;
 
   // Default values for user-accessible settings.
   static ThemeMode get defaultThemeMode => ThemeMode.system;

--- a/lib/src/features/track_list/presentation/track_list_screen.dart
+++ b/lib/src/features/track_list/presentation/track_list_screen.dart
@@ -68,6 +68,11 @@ class _TrackListScreenContentsState extends State<TrackListScreenContents> {
             ),
           ),
           const TracksList(),
+          SliverToBoxAdapter(
+            child: SizedBox(
+              height: Config.trackListScrollBottomPadding,
+            ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
The end of the track list scroll view now has a `SizedBox` inside of a `SliverToBoxAdapter`. The size is set with `Config.trackListScrollBottomPadding`. I set it to 120 for now. I decided against removing it in wide layouts in order the avoid having a tappable so close a part of the screen that might accidentally trigger app switching.