### PR TITLE
Change play buttons to stateful widgets and ignore loading.

### DIFF
--- a/lib/src/features/player/presentation/buttons.dart
+++ b/lib/src/features/player/presentation/buttons.dart
@@ -75,12 +75,47 @@ class _TappableButtonIcon extends StatelessWidget {
   }
 }
 
-class PlayPauseButton extends ConsumerWidget {
+/// In this version of Kantan Player all of the audio files are stored on device
+/// which means that loading is nearly instantaneous. However, when skipping
+/// tracks the app does very briefly pass through a loading state. Because this
+/// loading state is so brief, it's not helpful to communicate to the user. The
+/// design of this `StatefulWidget` prevents the icon from ever showing the
+/// loading state. In a future version of Kantan Player which can load audio
+/// over the web, showing the loading state can be re-enabled.
+class PlayPauseButton extends ConsumerStatefulWidget {
   const PlayPauseButton({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final playbackState = ref.watch(playPauseButtonControllerProvider);
+  ConsumerState<PlayPauseButton> createState() => _PlayPauseButtonState();
+}
+
+class _PlayPauseButtonState extends ConsumerState<PlayPauseButton> {
+  late KantanPlaybackState playbackState;
+
+  @override
+  void initState() {
+    super.initState();
+    final initState = ref.read(playPauseButtonControllerProvider);
+    setState(() => playbackState = initState);
+  }
+
+  @override
+  void dispose() => super.dispose();
+
+  void resolveState(KantanPlaybackState state) {
+    if (state == KantanPlaybackState.loading) {
+      return;
+    } else {
+      setState(() => playbackState = state);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<KantanPlaybackState>(
+      playPauseButtonControllerProvider,
+      (_, state) => resolveState(state),
+    );
 
     IconData buttonIcon = switch (playbackState) {
       KantanPlaybackState.loading ||

--- a/lib/src/features/player/presentation/mini_player_play_pause_button.dart
+++ b/lib/src/features/player/presentation/mini_player_play_pause_button.dart
@@ -4,12 +4,49 @@ import 'package:kantan/src/features/player/domain/kantan_playback_state.dart';
 import 'package:kantan/src/features/player/presentation/play_pause_button_controller.dart';
 import 'package:kantan/src/themes/theme_extensions.dart';
 
-class MiniPlayerPlayPauseButton extends ConsumerWidget {
+/// In this version of Kantan Player all of the audio files are stored on device
+/// which means that loading is nearly instantaneous. However, when skipping
+/// tracks the app does very briefly pass through a loading state. Because this
+/// loading state is so brief, it's not helpful to communicate to the user. The
+/// design of this `StatefulWidget` prevents the icon from ever showing the
+/// loading state. In a future version of Kantan Player which can load audio
+/// over the web, showing the loading state can be re-enabled.
+class MiniPlayerPlayPauseButton extends ConsumerStatefulWidget {
   const MiniPlayerPlayPauseButton({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final playbackState = ref.watch(playPauseButtonControllerProvider);
+  ConsumerState<MiniPlayerPlayPauseButton> createState() =>
+      _MiniPlayerPlayPauseButtonState();
+}
+
+class _MiniPlayerPlayPauseButtonState
+    extends ConsumerState<MiniPlayerPlayPauseButton> {
+  late KantanPlaybackState playbackState;
+
+  @override
+  void initState() {
+    super.initState();
+    final initState = ref.read(playPauseButtonControllerProvider);
+    setState(() => playbackState = initState);
+  }
+
+  @override
+  void dispose() => super.dispose();
+
+  void resolveState(KantanPlaybackState state) {
+    if (state == KantanPlaybackState.loading) {
+      return;
+    } else {
+      setState(() => playbackState = state);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<KantanPlaybackState>(
+      playPauseButtonControllerProvider,
+      (_, state) => resolveState(state),
+    );
 
     IconData buttonIcon = switch (playbackState) {
       KantanPlaybackState.loading ||

--- a/lib/src/features/transcript/presentation/transcript_player_controls.dart
+++ b/lib/src/features/transcript/presentation/transcript_player_controls.dart
@@ -231,12 +231,49 @@ class ExpandTranscriptButton extends StatelessWidget {
   }
 }
 
-class TranscriptPlayButton extends ConsumerWidget {
+/// In this version of Kantan Player all of the audio files are stored on device
+/// which means that loading is nearly instantaneous. However, when skipping
+/// tracks the app does very briefly pass through a loading state. Because this
+/// loading state is so brief, it's not helpful to communicate to the user. The
+/// design of this `StatefulWidget` prevents the icon from ever showing the
+/// loading state. In a future version of Kantan Player which can load audio
+/// over the web, showing the loading state can be re-enabled.
+class TranscriptPlayButton extends ConsumerStatefulWidget {
   const TranscriptPlayButton({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final playbackState = ref.watch(playPauseButtonControllerProvider);
+  ConsumerState<TranscriptPlayButton> createState() =>
+      _TranscriptPlayButtonState();
+}
+
+class _TranscriptPlayButtonState extends ConsumerState<TranscriptPlayButton> {
+  late KantanPlaybackState playbackState;
+
+  @override
+  void initState() {
+    super.initState();
+    final initState = ref.read(playPauseButtonControllerProvider);
+    setState(() => playbackState = initState);
+  }
+
+  @override
+  void dispose() => super.dispose();
+
+  void resolveState(KantanPlaybackState state) {
+    if (state == KantanPlaybackState.loading) {
+      return;
+    } else {
+      setState(() => playbackState = state);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<KantanPlaybackState>(
+      playPauseButtonControllerProvider,
+      (_, state) => resolveState(state),
+    );
+
     final style = Theme.of(context).extension<TranscriptScreenButtonStyle>();
 
     IconData buttonIcon = switch (playbackState) {


### PR DESCRIPTION
The three play buttons are now `ConsumerStatefulWidget`s with one state variable `KantanPlaybackState playbackState`.  The widgets no longer `watch` but rather `listen` to `playPauseButtonControllerProvider`. When the state of the provider changes to `KantanPlaybackState.loading` the state variable is not updated. If it's anything else, then the state variable is updated and the icon reflects that change.

In a future version of Kantan Player that can load audio over the web, and in which the loading state is more meaningful, then this behavior can be changed so that a loading state is communicated with the appropriate icon.